### PR TITLE
[patch] add go binary version during build time

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -215,14 +215,14 @@ workflows:
             branches:
               only:
                 - master
-      - versioning
-      - push:
-          requires:
-            - versioning
+      - versioning:
           filters:
             branches:
               only:
                 - master
+      - push:
+          requires:
+            - versioning
       - gh_release:
           requires:
             - push

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -214,14 +214,14 @@ workflows:
             branches:
               only:
                 - master
-      - versioning:
+      - versioning
+      - push:
+          requires:
+            - versioning
           filters:
             branches:
               only:
                 - master
-      - push:
-          requires:
-            - versioning
       - gh_release:
           requires:
             - push

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -52,8 +52,17 @@ jobs:
       - run:
           name: docker image build
           command: |
-            # env DOCKER_BUILDKIT=1 docker build -t ${REPO_NAME}/${IMAGE_NAME}:latest .
-            docker build -t ${REPO_NAME}/${IMAGE_NAME}:latest .
+            TAG=`cat ./.tag`
+            if [ ! -z "$TAG" ]; then
+              docker build --build-arg APP_VERSION=${TAG} -t ${REPO_NAME}/${IMAGE_NAME}:latest .
+            else
+              # env DOCKER_BUILDKIT=1 docker build -t ${REPO_NAME}/${IMAGE_NAME}:latest .
+              docker build -t ${REPO_NAME}/${IMAGE_NAME}:latest .
+            fi
+      - run:
+          name: check build version
+          command: |
+            docker run --name ${IMAGE_NAME} ${REPO_NAME}/${IMAGE_NAME}:latest --version
       - run:
           name: save image
           command: |
@@ -188,7 +197,9 @@ workflows:
   build:
     jobs:
       - test
-      - build
+      - build:
+          requires:
+            - versioning
       - publish_nightly:
           requires:
             - test

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -92,7 +92,7 @@ jobs:
           command: |
             docker login -u ${DOCKER_USER} -p ${DOCKER_PASS}
       - run:
-          name: push image to registory
+          name: push image to registry
           command: |
             docker push ${REPO_NAME}/${IMAGE_NAME}
   publish:
@@ -114,7 +114,7 @@ jobs:
           command: |
             docker login -u ${DOCKER_USER} -p ${DOCKER_PASS}
       - run:
-          name: push image to registory
+          name: push image to registry
           command: |
             docker push ${REPO_NAME}/${IMAGE_NAME}
   versioning:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -64,7 +64,7 @@ jobs:
       - run:
           name: check build version
           command: |
-            docker run --name ${IMAGE_NAME} ${REPO_NAME}/${IMAGE_NAME}:latest --version
+            docker run --rm --name ${IMAGE_NAME} ${REPO_NAME}/${IMAGE_NAME}:latest --version
       - run:
           name: save image
           command: |
@@ -155,7 +155,8 @@ jobs:
       - run:
           name: echo version
           command: |
-            cat ./.tag
+            TAG_FILE='./.tag' \
+            && if [[ -s ${TAG_FILE} ]]; then echo "TAG: `cat "${TAG_FILE}"`"; else echo "TAG: (${TAG_FILE} is empty)"; fi
       - persist_to_workspace:
           root: .
           paths:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -44,6 +44,8 @@ jobs:
     <<: *default
     steps:
       - setup_remote_docker: *setup_remote_docker
+      - attach_workspace:
+          at: .
       - checkout
       - run:
           name: check docker version

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -152,6 +152,10 @@ jobs:
                 echo "0.0.1" > ./.tag
               fi
             fi
+      - run:
+          name: echo version
+          command: |
+            cat ./.tag
       - persist_to_workspace:
           root: .
           paths:

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,7 @@
 FROM golang:1.13-alpine AS base
 
 RUN set -eux \
+    && apk update \
     && apk --no-cache add ca-certificates \
     && apk --no-cache add --virtual build-dependencies cmake g++ make unzip curl upx git
 
@@ -13,22 +14,21 @@ RUN GO111MODULE=on go mod download
 
 FROM base AS builder
 
-ARG APP_VERSION_DEFAULT='development version'
-
-ENV APP_NAME client
-ENV APP_VERSION $APP_VERSION_DEFAULT
+ENV APP_NAME athenz-client-sidecar
+ARG APP_VERSION='development version'
 
 COPY . .
 
-RUN CGO_ENABLED=1 \
+RUN BUILD_TIME=$(date -u +%Y%m%d-%H%M%S) \
+    && GO_VERSION=$(go version | cut -d" " -f3,4) \
+    && CGO_ENABLED=1 \
     CGO_CXXFLAGS="-g -Ofast -march=native" \
     CGO_FFLAGS="-g -Ofast -march=native" \
     CGO_LDFLAGS="-g -Ofast -march=native" \
     GOOS=$(go env GOOS) \
     GOARCH=$(go env GOARCH) \
     GO111MODULE=on \
-    BUILD_TIME=$(date -u +%Y%m%d-%H%M%S) \
-    go build --ldflags "-X main.Version=${APP_VERSION}.${BUILD_TIME} "'-s -w -linkmode "external" -extldflags "-static -fPIC -m64 -pthread -std=c++11 -lstdc++"' -a -tags "cgo netgo" -installsuffix "cgo netgo" -o "${APP_NAME}" \
+    go build -ldflags "-s -w -linkmode 'external' -extldflags '-static -fPIC -m64 -pthread -std=c++11 -lstdc++' -X 'main.Version=${APP_VERSION} at ${BUILD_TIME} by ${GO_VERSION}'" -a -tags "cgo netgo" -installsuffix "cgo netgo" -o "${APP_NAME}" \
     && upx --best -o "/usr/bin/${APP_NAME}" "${APP_NAME}"
 
 RUN apk del build-dependencies --purge \
@@ -39,7 +39,7 @@ FROM scratch
 # FROM alpine:latest
 LABEL maintainer "kpango <i.can.feel.gravity@gmail.com>"
 
-ENV APP_NAME client
+ENV APP_NAME athenz-client-sidecar
 
 # Copy certificates for SSL/TLS
 COPY --from=builder /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/
@@ -48,4 +48,4 @@ COPY --from=builder /etc/passwd /etc/passwd
 # Copy our static executable
 COPY --from=builder /usr/bin/${APP_NAME} /go/bin/${APP_NAME}
 
-ENTRYPOINT ["/go/bin/client"]
+ENTRYPOINT ["/go/bin/athenz-client-sidecar"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -13,7 +13,10 @@ RUN GO111MODULE=on go mod download
 
 FROM base AS builder
 
+ARG APP_VERSION_DEFAULT='development version'
+
 ENV APP_NAME client
+ENV APP_VERSION $APP_VERSION_DEFAULT
 
 COPY . .
 
@@ -24,7 +27,8 @@ RUN CGO_ENABLED=1 \
     GOOS=$(go env GOOS) \
     GOARCH=$(go env GOARCH) \
     GO111MODULE=on \
-    go build --ldflags '-s -w -linkmode "external" -extldflags "-static -fPIC -m64 -pthread -std=c++11 -lstdc++"' -a -tags "cgo netgo" -installsuffix "cgo netgo" -o "${APP_NAME}" \
+    BUILD_TIME=$(date -u +%Y%m%d-%H%M%S) \
+    go build --ldflags "-X main.Version=${APP_VERSION}.${BUILD_TIME} "'-s -w -linkmode "external" -extldflags "-static -fPIC -m64 -pthread -std=c++11 -lstdc++"' -a -tags "cgo netgo" -installsuffix "cgo netgo" -o "${APP_NAME}" \
     && upx --best -o "/usr/bin/${APP_NAME}" "${APP_NAME}"
 
 RUN apk del build-dependencies --purge \

--- a/main.go
+++ b/main.go
@@ -48,7 +48,7 @@ func parseParams() (*params, error) {
 	f.BoolVar(&p.showVersion,
 		"version",
 		false,
-		"show athenz clientd version")
+		"show athenz-client-sidecar version")
 
 	err := f.Parse(os.Args[1:])
 	if err != nil {
@@ -104,11 +104,11 @@ func main() {
 	}
 
 	if p.showVersion {
-		err := glg.Infof("athenz clientd version -> %s", getVersion())
+		err := glg.Infof("athenz-client-sidecar version -> %s", getVersion())
 		if err != nil {
 			glg.Fatal(err)
 		}
-		err = glg.Infof("athenz clientd config version -> %s", config.GetVersion())
+		err = glg.Infof("athenz-client-sidecar config version -> %s", config.GetVersion())
 		if err != nil {
 			glg.Fatal(err)
 		}

--- a/main.go
+++ b/main.go
@@ -30,6 +30,9 @@ import (
 	"github.com/yahoojapan/athenz-client-sidecar/usecase"
 )
 
+// Version gets set by the build script via LDFLAGS
+var Version string
+
 type params struct {
 	configFilePath string
 	showVersion    bool
@@ -101,7 +104,8 @@ func main() {
 	}
 
 	if p.showVersion {
-		glg.Infof("athenz clientd version -> %s", config.GetVersion())
+		glg.Infof("athenz clientd version -> %s", getVersion())
+		glg.Infof("athenz clientd config version -> %s", config.GetVersion())
 		return
 	}
 
@@ -121,4 +125,11 @@ func main() {
 		glg.Fatal(errs)
 		return
 	}
+}
+
+func getVersion() string {
+	if Version == "" {
+		return "development version"
+	}
+	return Version
 }

--- a/main.go
+++ b/main.go
@@ -104,8 +104,14 @@ func main() {
 	}
 
 	if p.showVersion {
-		glg.Infof("athenz clientd version -> %s", getVersion())
-		glg.Infof("athenz clientd config version -> %s", config.GetVersion())
+		err := glg.Infof("athenz clientd version -> %s", getVersion())
+		if err != nil {
+			glg.Fatal(err)
+		}
+		err = glg.Infof("athenz clientd config version -> %s", config.GetVersion())
+		if err != nil {
+			glg.Fatal(err)
+		}
 		return
 	}
 

--- a/main.go
+++ b/main.go
@@ -30,7 +30,7 @@ import (
 	"github.com/yahoojapan/athenz-client-sidecar/usecase"
 )
 
-// Version gets set by the build script via LDFLAGS
+// Version is set by the build command via LDFLAGS
 var Version string
 
 type params struct {

--- a/main_test.go
+++ b/main_test.go
@@ -1,0 +1,177 @@
+package main
+
+import (
+	"os"
+	"testing"
+
+	"github.com/pkg/errors"
+	"github.com/yahoojapan/athenz-client-sidecar/config"
+)
+
+func TestParseParams(t *testing.T) {
+	type test struct {
+		name       string
+		beforeFunc func()
+		checkFunc  func(*params) error
+		checkErr   bool
+	}
+	tests := []test{
+		func() test {
+			return test{
+				name: "check parseParams set default value",
+				beforeFunc: func() {
+					os.Args = []string{""}
+				},
+				checkFunc: func(p *params) error {
+					if p.configFilePath != "/etc/athenz/client/config.yaml" {
+						return errors.Errorf("unexpected file path. got: %s, want: /etc/athenz/client/config.yaml", p.configFilePath)
+					}
+					if p.showVersion != false {
+						return errors.Errorf("unexpected showVersion flag. got: %v, want : false", p.showVersion)
+					}
+					return nil
+				},
+				checkErr: false,
+			}
+		}(),
+		func() test {
+			return test{
+				name: "check parse error",
+				checkFunc: func(p *params) error {
+					return nil
+				},
+				beforeFunc: func() {
+					os.Args = []string{"", "-="}
+				},
+				checkErr: true,
+			}
+		}(),
+		func() test {
+			return test{
+				name: "check parseParams set user flags",
+				beforeFunc: func() {
+					os.Args = []string{"", "-f", "/dummy/path", "-version", "true"}
+				},
+				checkFunc: func(p *params) error {
+					if p.configFilePath != "/dummy/path" {
+						return errors.Errorf("unexpected file path. got: %s, want: /dummy/path", p.configFilePath)
+					}
+					if p.showVersion != true {
+						return errors.Errorf("unexpected showVersion flag. got: %v, want: true", p.showVersion)
+					}
+
+					return nil
+				},
+				checkErr: false,
+			}
+		}(),
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if tt.beforeFunc != nil {
+				tt.beforeFunc()
+			}
+
+			got, err := parseParams()
+			if err != nil && !tt.checkErr {
+				t.Errorf("unexpected error: %v", err)
+			}
+			if err := tt.checkFunc(got); err != nil {
+				t.Errorf("checkFunc() error: %v", err)
+			}
+		})
+	}
+}
+
+func Test_run(t *testing.T) {
+	type args struct {
+		cfg config.Config
+	}
+	type test struct {
+		name      string
+		args      args
+		checkFunc func(config.Config) error
+	}
+	tests := []test{
+		func() test {
+			return test{
+				name: "run error",
+				args: args{
+					cfg: config.Config{
+						Token: config.Token{
+							AthenzDomain:    "domain",
+							ServiceName:     "service",
+							RefreshDuration: "1h",
+							KeyVersion:      "keyId",
+							Expiration:      "1h",
+							PrivateKeyPath:  "./usecase/assets/dummyServer.key",
+						},
+						Role: config.Role{
+							RefreshInterval: "dummy",
+						},
+					},
+				},
+				checkFunc: func(cfg config.Config) error {
+					got := run(cfg)
+					want := "RefreshInterval: time: invalid duration dummy: Invalid config"
+					if len(got) != 1 {
+						return errors.New("len(got) != 1")
+					}
+					if got[0].Error() != want {
+						return errors.Errorf("got: %v, want: %v", got[0], want)
+					}
+					return nil
+				},
+			}
+		}(),
+		func() test {
+			return test{
+				name: "daemon init error",
+				args: args{
+					cfg: config.Config{
+						Token: config.Token{
+							RefreshDuration: "dummy",
+						},
+					},
+				},
+				checkFunc: func(cfg config.Config) error {
+					got := run(cfg)
+					want := "invalid token refresh duration dummy, time: invalid duration dummy"
+					if len(got) != 1 {
+						return errors.New("len(got) != 1")
+					}
+					if got[0].Error() != want {
+						return errors.Errorf("got: %v, want: %v", got[0], want)
+					}
+					return nil
+				},
+			}
+		}(),
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if err := tt.checkFunc(tt.args.cfg); err != nil {
+				t.Errorf("run() error = %v", err)
+			}
+		})
+	}
+}
+
+func Test_getVersion(t *testing.T) {
+	tests := []struct {
+		name string
+		want string
+	}{
+		{
+			name: "default",
+			want: "development version",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := getVersion(); got != tt.want {
+				t.Errorf("getVersion() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/usecase/tenantd.go
+++ b/usecase/tenantd.go
@@ -97,7 +97,7 @@ func createNtokend(cfg config.Token) (ntokend.TokenService, error) {
 	keyData, err := ioutil.ReadFile(config.GetActualValue(cfg.PrivateKeyPath))
 	if err != nil && keyData == nil {
 		if cfg.NTokenPath == "" {
-			return nil, fmt.Errorf("invalid token certificate %v", err)
+			return nil, fmt.Errorf("invalid token private key %v", err)
 		}
 	}
 

--- a/usecase/tenantd_test.go
+++ b/usecase/tenantd_test.go
@@ -317,7 +317,7 @@ func Test_createNtokend(t *testing.T) {
 				afterFunc: func() {
 					os.Unsetenv(strings.TrimPrefix(strings.TrimSuffix(keyKey, "_"), "_"))
 				},
-				wantErr: fmt.Errorf("invalid token certificate open %v", "notexists: no such file or directory"),
+				wantErr: fmt.Errorf("invalid token private key open %v", "notexists: no such file or directory"),
 			}
 		}(),
 		func() test {


### PR DESCRIPTION
# issue
go binary only print the config file format version currently

# format
`${APP_VERSION} at ${BUILD_TIME} by ${GO_VERSION}`
e.g. `1.2.33333 at 20200128-025155 by go1.13.6 linux/amd64`

# TODO
- [x] also add go binary version during building
- [x] verify PR
- [x] fix other sidecars