### PR TITLE
[patch] version is not added on released steps

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -54,7 +54,12 @@ jobs:
       - run:
           name: docker image build
           command: |
-            TAG=`cat ./.tag`
+            if [ ! -z "$CIRCLE_TAG" ]; then
+              echo '$CIRCLE_TAG exists, use: '"$CIRCLE_TAG"
+              TAG="$CIRCLE_TAG"
+            elif [ -f ./.tag ]; then
+              TAG=`cat ./.tag`
+            fi
             if [ ! -z "$TAG" ]; then
               docker build --build-arg APP_VERSION=${TAG} -t ${REPO_NAME}/${IMAGE_NAME}:latest .
             else
@@ -204,6 +209,7 @@ workflows:
   build:
     jobs:
       - test
+      - versioning
       - build:
           requires:
             - versioning
@@ -215,12 +221,11 @@ workflows:
             branches:
               only:
                 - master
-      - versioning:
+      - push:
           filters:
             branches:
               only:
                 - master
-      - push:
           requires:
             - versioning
       - gh_release:
@@ -228,15 +233,7 @@ workflows:
             - push
   release:
     jobs:
-      - versioning:
-          filters:
-            branches:
-              ignore: /.*/
-            tags:
-              only: /[0-9]+\.[0-9]+\.[0-9]+/
       - build:
-          requires:
-            - versioning
           filters:
             branches:
               ignore: /.*/


### PR DESCRIPTION
1. fix: version is not added on released steps
    - previous release log
        - https://app.circleci.com/jobs/github/yahoojapan/athenz-client-sidecar/427/parallel-runs/0/steps/0-103
        - https://app.circleci.com/jobs/github/yahoojapan/athenz-client-sidecar/428/parallel-runs/0/steps/0-106
2. run docker build on PR too