### PR TITLE
[patch] push to nightly only

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -99,7 +99,7 @@ jobs:
       - run:
           name: push image to registry
           command: |
-            docker push ${REPO_NAME}/${IMAGE_NAME}
+            docker push ${REPO_NAME}/${IMAGE_NAME}:nightly
   publish:
     <<: *default
     steps:


### PR DESCRIPTION
The `publish_nightly` push to `latest` and `nightly` currently.
https://app.circleci.com/jobs/github/yahoojapan/athenz-client-sidecar/442/parallel-runs/0/steps/0-106
