### PR TITLE
[patch] remove ntokend enable check

### DIFF
--- a/usecase/tenantd.go
+++ b/usecase/tenantd.go
@@ -156,10 +156,6 @@ func (t *clientd) Start(ctx context.Context) chan []error {
 // createNtokend returns a TokenService object or any error
 func createNtokend(cfg config.NToken) (ntokend.TokenService, error) {
 
-	if !cfg.Enable {
-		return nil, errors.New("Disabled")
-	}
-
 	dur, err := time.ParseDuration(cfg.RefreshPeriod)
 	if err != nil {
 		return nil, fmt.Errorf("invalid token refresh period %s, %v", cfg.RefreshPeriod, err)

--- a/usecase/tenantd_test.go
+++ b/usecase/tenantd_test.go
@@ -426,19 +426,9 @@ func Test_createNtokend(t *testing.T) {
 	}
 	tests := []test{
 		{
-			name: "disabled",
-			args: args{
-				cfg: config.NToken{
-					Enable: false,
-				},
-			},
-			wantErr: fmt.Errorf("Disabled"),
-		},
-		{
 			name: "refresh period invalid",
 			args: args{
 				cfg: config.NToken{
-					Enable:        true,
 					RefreshPeriod: "dummy",
 				},
 			},
@@ -448,7 +438,6 @@ func Test_createNtokend(t *testing.T) {
 			name: "token expiry invalid",
 			args: args{
 				cfg: config.NToken{
-					Enable:        true,
 					RefreshPeriod: "1s",
 					Expiry:        "dummy",
 				},
@@ -464,7 +453,6 @@ func Test_createNtokend(t *testing.T) {
 				args: func() args {
 					return args{
 						cfg: config.NToken{
-							Enable:         true,
 							RefreshPeriod:  "1m",
 							Expiry:         "1m",
 							PrivateKeyPath: keyKey,
@@ -490,7 +478,6 @@ func Test_createNtokend(t *testing.T) {
 
 					return args{
 						cfg: config.NToken{
-							Enable:            true,
 							RefreshPeriod:     "1m",
 							Expiry:            "1m",
 							PrivateKeyPath:    keyKey,
@@ -511,7 +498,6 @@ func Test_createNtokend(t *testing.T) {
 			keyKey := "_dummyKey_"
 			key := "../test/data/dummyServer.key"
 			cfg := config.NToken{
-				Enable:            true,
 				AthenzDomain:      strings.TrimPrefix(strings.TrimSuffix(keyKey, "_"), "_"),
 				ServiceName:       strings.TrimPrefix(strings.TrimSuffix(keyKey, "_"), "_"),
 				ExistingTokenPath: "",


### PR DESCRIPTION
# Description

sidecar cannot start up when `nToken.enable: false, roleToken.enable: true`
```console
2021-08-18 06:58:42	[INFO]:	Requires ntokend as role token endpoint is enabled, and client certificate is not set
2021-08-18 06:58:42	[FATAL]:	(https://github.com/kpango/glg/blob/v1.6.4/glg.go#L1381):	[tenant error: ntokend error: Disabled]
```

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Non-code changes (update documentation, pipeline, etc.)

### Flags

- [ ] breaks backward compatibility
- [ ] requires a documentation update
- [ ] has untestable code

## Related issue/PR

- old PR: https://github.com/yahoojapan/athenz-client-sidecar/pull/44

---

## Checklist

- [x] Followed the guidelines in the CONTRIBUTING document
- [x] Added prefix `[major]`/`[minor]`/`[patch]`/`[skip]` in the PR title
- [x] Tested and linted the code
- [x] Commented the code
- [x] Made corresponding changes to the documentation
- [x] Confirmed no dropping in test coverage (by [Codecov](https://codecov.io/gh/yahoojapan/athenz-client-sidecar/pulls))
- [ ] Passed all pipeline checking
- [ ] Approved by >1 reviewer

## Checklist for maintainer
- [ ] Use `Squash and merge`
- [ ] Double-confirm the merge message has prefix `[major]`/`[minor]`/`[patch]`/`[skip]`
- [ ] Delete the branch after merge
